### PR TITLE
Disable text selection on spelling page

### DIFF
--- a/spelling/index.html
+++ b/spelling/index.html
@@ -15,6 +15,8 @@
       height: 100vh;
       margin: 0;
       font-family: sans-serif;
+      -webkit-user-select: none;
+      user-select: none;
     }
     #word {
       font-size: 8rem;


### PR DESCRIPTION
## Summary
- Prevent text from being highlighted on the Spelling page by disabling user selection via CSS.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bfb2bc5b508322a443ee4288507895